### PR TITLE
[livecd-cli-installer] fix incomplete call to write_x11_config

### DIFF
--- a/livecd-cli-installer/opt/livecd/km
+++ b/livecd-cli-installer/opt/livecd/km
@@ -66,7 +66,7 @@ dokeymap(){
     # Setup x11 config file
     local KBLAYOUT=$(get_layout)
     local KEYMAP=$(cat /tmp/.keymap | sed -e 's/\..*//g')
-    write_x11_config
+    write_x11_config /install
 
 S_NEXTITEM=2
 }


### PR DESCRIPTION
Forgot to add _/install_ prefix required when configuring installed system with cli-installer.

write_x11_config function is present at https://github.com/manjaro/manjaro-tools/blob/master/lib/util-livecd.sh