### PR TITLE
do not export $BROWSER

### DIFF
--- a/lib/util-live.sh
+++ b/lib/util-live.sh
@@ -360,10 +360,6 @@ configure_sudo(){
 }
 
 configure_env(){
-	echo "BROWSER=/usr/bin/xdg-open" >> /etc/environment
-	echo "BROWSER=/usr/bin/xdg-open" >> /etc/skel/.bashrc
-	echo "BROWSER=/usr/bin/xdg-open" >> /etc/profile
-
 	# add TERM var
 	if [ -e "/usr/bin/mate-session" ] ; then
 		echo "TERM=mate-terminal" >> /etc/environment


### PR DESCRIPTION
Tested on Xfce.
**exo** handles links fine when browser is set in [**~/.config/xfce4/helpers.rc**](https://github.com/manjaro/manjaro-xfce-settings/blob/master/skel/.config/xfce4/helpers.rc)